### PR TITLE
fix: internal cheatsheet now makes a deep-copy, and works reliably

### DIFF
--- a/lua/nvchad/cheatsheet.lua
+++ b/lua/nvchad/cheatsheet.lua
@@ -195,7 +195,8 @@ end
 local cheatsheet = {}
 
 cheatsheet.show = function()
-   local mappings = require("core.utils").load_config().mappings
+   -- Lua is copy by reference so make a deep copy of the table
+   local mappings = vim.deepcopy(require("core.utils").load_config().mappings)
    local pluginMappings = mappings.plugins
    mappings.plugins = nil
 


### PR DESCRIPTION
This should fix the minor bug described by [alaindresse](https://github.com/alaindresse)

Bug report here: https://github.com/NvChad/extensions/issues/5#issuecomment-998546771

@siduck 


This changes the function to make a copy of the load_config() table, instead of modifying it.
Lua is pass by reference, so it was previously modifying the table and thus behavior changed from the second run onward.