### PR TITLE
fixed bug: NvChad/extensions#7

### DIFF
--- a/lua/nvchad/cheatsheet.lua
+++ b/lua/nvchad/cheatsheet.lua
@@ -66,6 +66,10 @@ local function display_cheatsheet(mappings)
             line_nr = line_nr + 1
 
             for mapping, key in pairs(values) do
+               if type(key) == "boolean" and not key then
+                  goto continue -- the continue tag is at the end of the for loop
+               end
+
                if type(key) == "string" then
                   key = parse_mapping(key)
                   table.insert(
@@ -115,6 +119,7 @@ local function display_cheatsheet(mappings)
                      end
                   end
                end
+               ::continue::
             end
 
             table.insert(lines, spaces(spacing) .. "▙" .. string.rep("▄", 36) .. "▟")


### PR DESCRIPTION
fixes NvChad/extensions#7

When someone makes a keymapping `false` the keymapping is not displayed at all. I am confused about what to do when they type in the `true` boolean as the same error will occur. I propose if they type in true, it will use the same keymapping as in the default config. However, for the `true` feature to be added, we need to edit the `load_config` function in the `utils.lua` file in the `core` directory instead.

Any thoughts?