### PR TITLE
fix showing in bufferline and nvimtree overlap

### DIFF
--- a/lua/nvchad/terminal.lua
+++ b/lua/nvchad/terminal.lua
@@ -1,10 +1,22 @@
 local M = {}
 
+
 local chadterms = {
+   types = {"horizontal", "vertical"},
    horizontal = {},
    vertical = {},
-   winsize = {vertical=.5, horizontal=.5}
+   last = nil,
+   winsize = {vertical=.5, horizontal=.5},
+   location = {
+      horizontal = "rightbelow",
+      vertical = "rightbelow",
+   }
 }
+
+local add_term = function (direction, term)
+   table.insert(chadterms[direction], term)
+   chadterms.last = term
+end
 
 local get_cmds = function(direction)
    local get_dims = function()
@@ -12,91 +24,85 @@ local get_cmds = function(direction)
       local direction_func = direction_switch and vim.api.nvim_win_get_height or vim.api.nvim_win_get_width
       return math.floor(direction_func(0) * chadterms.winsize[direction])
    end
-   local dims = {
-      horizontal = get_dims(),
-      vertical = get_dims(),
-   }
-   local cmds = {
-      horizontal = {
-         existing = "rightbelow vsplit",
-         new = "botright " .. dims.horizontal .. " split",
-         resize = "resize",
-      },
-      vertical = {
-         existing = "rightbelow split",
-         new = dims.vertical .. " vsplit",
-         resize = "vertical resize",
-      },
-   }
-   return cmds
-end
-
-local function on_new_buf(opts)
-   local bufs = vim.api.nvim_list_bufs()
-   local term_buf_id = bufs[#bufs]
-   vim.api.nvim_buf_set_var(term_buf_id, "term_type", opts.direction)
-   vim.api.nvim_input "i" --term enter
-   return term_buf_id
-end
-
-local function on_new_win()
-   local wins = vim.api.nvim_list_wins()
-   local term_win_id = wins[#wins]
-   vim.api.nvim_set_current_win(term_win_id)
-   return term_win_id
-end
-local function spawn(spawn_cmd, type, opts)
-   vim.cmd(spawn_cmd)
-   return type == "win" and on_new_win() or type == "buf" and on_new_buf(opts)
-end
-
-M.new_or_toggle = function(direction)
-   local cmds = get_cmds(direction)
-
-   local function new_term()
-      local term_win_id = spawn(cmds[direction]["new"], "win")
-      local term_buf_id = spawn("term", "buf", {direction=direction})
-      chadterms[direction][1] = { win = term_win_id, buf = term_buf_id }
+   local term_cmds = function (dims)
+      if direction == "horizontal" then
+         return {new = chadterms.location.horizontal .. dims .. " split" }
+      end
+      return { new = chadterms.location.vertical .. dims .. " vsplit" }
    end
+   return term_cmds(get_dims()).new
+end
 
-   local function hide_term()
-      local term_id = chadterms[direction][1]["win"]
-      vim.api.nvim_set_current_win(term_id)
-      vim.cmd "hide"
-      --no update necessary, win will be invalid on hide
+local last_direction = function (direction)
+   return chadterms[direction][#chadterms[direction]]
+end
+
+M.hide_term = function (term)
+   term.open = false
+   vim.api.nvim_win_hide(term.win)
+end
+
+M.show_term = function (term)
+   term.open = true
+   vim.cmd(get_cmds(term.type))
+   term.win = vim.api.nvim_get_current_win()
+   vim.api.nvim_set_current_win(term.win)
+   vim.api.nvim_set_current_buf(term.buf)
+   vim.api.nvim_input("i") --term enter
+end
+
+M.hide = function (direction)
+   local term = direction and last_direction(direction) or chadterms.last
+   M.hide_term(term)
+end
+
+M.show = function(direction)
+   local term = direction and last_direction(direction) or chadterms.last
+   M.show_term(term)
+end
+
+M.new = function (direction)
+   local create_term = function ()
+      vim.cmd(get_cmds(direction))
+      local win = vim.api.nvim_get_current_win()
+      local buf = vim.api.nvim_create_buf(false, true)
+      return { win = win, buf = buf, open = true, type=direction }
    end
+   local term = create_term()
+   add_term(direction, term)
+   vim.api.nvim_win_set_buf(term.win, term.buf)
+   vim.cmd("term")
+   vim.api.nvim_buf_set_option(term.buf, 'buflisted', false)
+end
 
-   local function show_term()
-      local term_buf_id = chadterms[direction][1]["buf"]
-      local term_win_id = spawn(cmds[direction]["new"], "win")
-      vim.api.nvim_set_current_buf(term_buf_id)
-      vim.api.nvim_input "i" --term enter
-      chadterms[direction][1] = { win = term_win_id, buf = term_buf_id }
-   end
-
-   local opened = chadterms[direction]
-   if not opened or vim.tbl_isempty(opened) then
-      new_term()
-   elseif vim.api.nvim_win_is_valid(chadterms[direction][1]["win"]) then
-      hide_term()
-   elseif vim.api.nvim_buf_is_valid(chadterms[direction][1]["buf"]) then
-      show_term()
-   else
-      new_term()
+local verify_terminals = function ()
+   for _, type in ipairs(chadterms.types) do
+      chadterms[type] = vim.tbl_filter(function(term)
+         return vim.api.nvim_buf_is_valid(term.buf)
+      end, chadterms[type])
    end
 end
 
-local behavior_handler = function(behavior)
-   if behavior.close_on_exit then
-      vim.cmd "au TermClose * lua vim.api.nvim_input('<CR>')"
-   end
-   vim.cmd [[ au TermOpen term://* setlocal nonumber norelativenumber | setfiletype terminal ]]
+M.new_or_toggle = function (direction)
+   verify_terminals()
+   local term = last_direction(direction)
+   if vim.tbl_isempty(chadterms[direction]) then M.new(direction) return end
+   if term.open then M.hide_term(term) return end
+   M.show_term(term)
 end
+
 
 local config_handler = function(config)
+   local behavior_handler = function(behavior)
+      if behavior.close_on_exit then
+         vim.cmd "au TermClose * lua vim.api.nvim_input('<CR>')"
+      end
+      vim.cmd [[ au TermOpen term://* setlocal nonumber norelativenumber | setfiletype terminal | startinsert]]
+   end
    behavior_handler(config["behavior"])
    chadterms.winsize["horizontal"] = config.window.split_ratio or .5
    chadterms.winsize["vertical"] = config.window.vsplit_ratio or .5
+   chadterms.location = config.location or chadterms.location
 end
 
 M.init = function()


### PR DESCRIPTION
Also added new option for controlling split method. Default is rightbelow which does not overlap with nvimtree.

Misc api changes as well to make directionless showing and hiding from hotkeys easier once I add in a little more stuff later. Also put in a few vars that will help when I get to adding floats.