### PR TITLE
fix: create custom dir + chadrc if it does not exist after selecting theme

### DIFF
--- a/lua/nvchad/change_theme.lua
+++ b/lua/nvchad/change_theme.lua
@@ -12,7 +12,20 @@ local function change_theme(current_theme, new_theme)
    local file = vim.fn.stdpath "config" .. "/lua/custom/" .. "chadrc.lua"
 
    -- store in data variable
-   local data = assert(file_fn("r", file))
+   local data = file_fn("r", file)
+
+   -- check if data is false or nil and create a default file if it is
+   if not data then
+      file_fn("w", file, 'local M = {}\n\nM.ui = {\n   theme = "' .. new_theme .. '",\n}\n\nreturn M')
+      data = file_fn("r", file)
+   end
+
+   -- if the file was still not created, then something went wrong
+   if not data then
+      print("Error: Could not create: " .. file .. ". Please create it manually to set a default "
+         .. "theme. Look at the documentation for more info.")
+      return false
+   end
 
    -- escape characters which can be parsed as magic chars
    current_theme = current_theme:gsub("%p", "%%%0")

--- a/lua/nvchad/init.lua
+++ b/lua/nvchad/init.lua
@@ -51,6 +51,11 @@ end
 -- return file data on read, nothing on write
 M.file = function(mode, filepath, content)
    local data
+   local base_dir = vim.fn.fnamemodify(filepath, ":h")
+   -- check if file exists in filepath, return false if not
+   if mode == "r" and vim.fn.filereadable(filepath) == 0 then return false end
+   -- check if directory exists, create it and all parents if not
+   if mode == "w" and vim.fn.isdirectory(base_dir) == 0 then vim.fn.mkdir(base_dir, "p") end
    local fd = assert(vim.loop.fs_open(filepath, mode, 438))
    local stat = assert(vim.loop.fs_fstat(fd))
    if stat.type ~= "file" then


### PR DESCRIPTION
@siduck This fixes this https://github.com/NvChad/NvChad/issues/1047#issuecomment-1132996788, also mentioned in this https://www.reddit.com/r/neovim/comments/utukok/i_cant_change_the_theme_in_neovim_nvchad/i9bruh4/?context=3. NvChad will now create the custom dir + default minimal chadrc if it does not already exist and set the selected theme as a value for `M.ui.theme`.