### PR TITLE
Fix renamer.lua

### DIFF
--- a/lua/nvchad/ui/renamer.lua
+++ b/lua/nvchad/ui/renamer.lua
@@ -32,7 +32,7 @@ M.open = function()
       0,
       "i",
       "<CR>",
-      "<cmd>stopinsert | lua require'ui.renamer'.apply(" .. currName .. "," .. win .. ")<CR>",
+      "<cmd>stopinsert | lua require'nvchad.ui.renamer'.apply(" .. currName .. "," .. win .. ")<CR>",
       map_opts
    )
 
@@ -40,7 +40,7 @@ M.open = function()
       0,
       "n",
       "<CR>",
-      "<cmd>stopinsert | lua require'ui.renamer'.apply(" .. currName .. "," .. win .. ")<CR>",
+      "<cmd>stopinsert | lua require'nvchad.ui.renamer'.apply(" .. currName .. "," .. win .. ")<CR>",
       map_opts
    )
 end


### PR DESCRIPTION
Fix `E5108: Error executing lua [string ":lua"]:1: module 'ui.renamer' not found`` Error.