### PR TITLE
fix: get_commit_list_by_hash_range

### DIFF
--- a/lua/nvchad/utils/git.lua
+++ b/lua/nvchad/utils/git.lua
@@ -237,7 +237,7 @@ M.get_commit_list_by_hash_range = function(start_hash, end_hash)
    local commit_list_string = utils.cmd(
       "git -C "
       .. M.config_path
-      .. " log --oneline --no-merges --decorate --date=short --pretty='format:%ad: %h %s' "
+      .. " log --oneline --no-merges --decorate --date=short --pretty=\"format:%ad: %h %s\" "
       .. start_hash
       .. ".."
       .. end_hash,


### PR DESCRIPTION
When updating nvchad, there was an error (below) that didn't affect the upgrade, but couldn't show the changes.

Change `'` to `\"` can fix it.

```
fatal: ambiguous argument '%h': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```