### PR TITLE
fix: allow hyphens and slashes in branch names

### DIFF
--- a/lua/nvchad/utils/git.lua
+++ b/lua/nvchad/utils/git.lua
@@ -120,7 +120,7 @@ M.get_current_branch_name = function()
   local result = utils.cmd("git -C " .. M.config_path .. " rev-parse --abbrev-ref HEAD", false)
 
   if result then
-    return result:match "([%w\\_\\-.]*)"
+    return result:match "([%w\\_%-./]*)"
   end
 
   return ""


### PR DESCRIPTION
When I updated NvChad on the `foo/bar-baz` branch, I got the following message:
```
Checking out branch foo/bar-baz failed! Current branch is: foo.
```

This is because the hyphen and slash are not allowed in the regular expression when retrieving the branch name.
So I fixed it.