### PR TITLE
Create User AutoCommand Event on theme reload

### DIFF
--- a/lua/nvchad/reload_theme.lua
+++ b/lua/nvchad/reload_theme.lua
@@ -17,7 +17,9 @@ local function reload_theme(theme_name)
 
   vim.g.nvchad_theme = theme_name
   require("base46").load_all_highlights()
-
+  
+  vim.cmd "doautocmd User NvChadThemeReload"
+  
   return true
 end
 

--- a/lua/nvchad/reload_theme.lua
+++ b/lua/nvchad/reload_theme.lua
@@ -18,7 +18,7 @@ local function reload_theme(theme_name)
   vim.g.nvchad_theme = theme_name
   require("base46").load_all_highlights()
   
-  vim.cmd "doautocmd User NvChadThemeReload"
+  vim.api.nvim_exec_autocmds("User", { pattern = " NvChadThemeReload" })
   
   return true
 end


### PR DESCRIPTION
Added User AutoCommand NvChadThemeReload so that users can listen for this event on theme reload.

### Demonstration of Feature:

![nvchad_reload](https://user-images.githubusercontent.com/16690478/184060088-6ff89309-7754-4569-9300-d9d022bc3592.gif)

