### PR TITLE
Typo in NvChadThemeReload doautocmd event

### DIFF
--- a/lua/nvchad/reload_theme.lua
+++ b/lua/nvchad/reload_theme.lua
@@ -18,7 +18,7 @@ local function reload_theme(theme_name)
   vim.g.nvchad_theme = theme_name
   require("base46").load_all_highlights()
   
-  vim.api.nvim_exec_autocmds("User", { pattern = " NvChadThemeReload" })
+  vim.api.nvim_exec_autocmds("User", { pattern = "NvChadThemeReload" })
   
   return true
 end


### PR DESCRIPTION
Autocommands are space-sensitive, should work properly now!