### PR TITLE
add instructions on colors bases

### DIFF
--- a/nvchad_types/base46.lua
+++ b/nvchad_types/base46.lua
@@ -149,7 +149,7 @@
 ---@field teal string Dev/CMP Icons
 ---@field orange string Diff Mod
 ---@field cyan string Dev/CMP Icons
----@field statusline_bg string
+---@field statusline_bg string Statusline
 ---@field lightbg string Statusline Components
 ---@field pmenu_bg string Pop-up Menu Selection
 ---@field folder_bg string Nvimtree Items

--- a/nvchad_types/base46.lua
+++ b/nvchad_types/base46.lua
@@ -2,9 +2,9 @@
 
 --- List of options for `vim.api.nvim_set_hl`
 ---@class APISetHighlightOpts
----@field fg string Color of foreground
----@field bg string color of background
----@field sp string Color of underlines. Read more at `:h guisp`. 
+---@field fg string Color name or Hex code of foreground
+---@field bg string Color name or Hex code of background
+---@field sp string Color of underlines. Read more at `:h guisp`.
 ---@field blend number integer between 0 and 100, level of opacity
 ---@field bold boolean bolded text or not
 ---@field standout boolean decorations
@@ -15,9 +15,9 @@
 ---@field underdashed boolean
 ---@field strikethrough boolean
 ---@field italic boolean italicized text
----@field reverse boolean 
+---@field reverse boolean
 ---@field nocombine boolean
---- name of another highlight group to link to, see `:h hi-link` for more information. 
+--- name of another highlight group to link to, see `:h hi-link` for more information.
 --- When this is not null, all attributes will be overriden if the linked group has such attribute defined
 --- To unlink a hlgroup, do `link = "NONE"`
 ---@field link string|'"NONE"'
@@ -27,17 +27,17 @@
 ---@field cterm string comma-separated list of cterm opts. For more information, check `:h highlight-args`
 
 ---@class Base46HLGroups : APISetHighlightOpts
---- Color of foreground
+--- Color name or Hex code of foreground
 --- if fg is "NONE", remove the foreground color
 ---@field fg string|Base30Colors|'"NONE"'
---- Color of background
+--- Color name or Hex code of background
 --- if fg is "NONE", remove the background color
 ---@field bg string|Base30Colors|'"NONE"' color of background
 --- Used for underline colors
 --- - If sp is `NONE`, use transparent color for special
 --- - If sp is `bg` or `background`, use normal background color
 --- - If sp is `fg` or `foreground`, use normal foreground color
---- See :h guisp for more information 
+--- See :h guisp for more information
 ---@field sp string|Base30Colors|'"NONE"'|'"bg"'|'"background"'|'"fg"'|'"foreground"'
 
 ---@alias HLTable table<string, Base46HLGroups>
@@ -97,7 +97,7 @@
 ---| Base16Colors
 
 ---@class ThemeTable
----@field base_16 Base16Table base00-base0F colors 
+---@field base_16 Base16Table base00-base0F colors
 ---@field base_30 Base30Table extra colors to use
 
 ---@class Base46Table : ThemeTable
@@ -105,51 +105,51 @@
 ---@field type '"dark"'|'"light"' Denoting value to set for `vim.opt.bg`
 
 ---@class Base16Table
----@field base00 string
----@field base01 string
----@field base02 string
----@field base03 string
----@field base04 string
----@field base05 string
----@field base06 string
----@field base07 string
----@field base08 string
----@field base09 string
----@field base0A string
----@field base0B string
----@field base0C string
----@field base0D string
----@field base0E string
----@field base0F string
+---@field base00 string Neovim Default Background
+---@field base01 string Lighter Background (Used for status bars, line number and folding marks)
+---@field base02 string Selection Background (Visual Mode)
+---@field base03 string Comments, Invisibles, Line Highlighting, Special Keys, Sings, Fold bg
+---@field base04 string Dark Foreground, Dnf Underline (Used for status bars)
+---@field base05 string Default Foreground (for text), Var, Refrences Caret, Delimiters, Operators
+---@field base06 string Light Foreground (Not often used)
+---@field base07 string Light Foreground, Cmp Icons (Not often used)
+---@field base08 string Variables, Identifiers, Filed, Name Space, Error, Spell XML Tags, Markup Link Text, Markup Lists, Diff Deleted
+---@field base09 string Integers, Boolean, Constants, XML Attributes, Markup Link Url, Inc Search
+---@field base0A string Classes, Attribute, Type, Repeat, Tag, Todo, Markup Bold, Search Text Background
+---@field base0B string Strings, Symbols, Inherited Class, Markup Code, Diff Inserted
+---@field base0C string Constructor,Special, Fold Column, Support, Regular Expressions, Escape Characters, Markup Quotes
+---@field base0D string Functions, Methods, Attribute IDs, Headings
+---@field base0E string Keywords, Storage, Selector, Markup Italic, Diff Changed
+---@field base0F string Delimiters, Special Char, Deprecated, Opening/Closing Embedded Language Tags, e.g. <?php ?>
 
 ---@class Base30Table
 ---@field white string
----@field darker_black string
----@field black string
----@field black2 string
----@field one_bg string
----@field one_bg2 string
----@field one_bg3 string
----@field grey string
----@field grey_fg string
----@field grey_fg2 string
----@field light_grey string
----@field red string
----@field baby_pink string
----@field pink string
----@field line string
----@field green string
----@field vibrant_green string
----@field blue string
----@field nord_blue string
----@field yellow string
----@field sun string
----@field purple string
----@field dark_purple string
----@field teal string
----@field orange string
----@field cyan string
+---@field darker_black string LSP/CMP Pop-ups, Tree BG
+---@field black string CMP BG, Icons/Headers FG
+---@field black2 string Tabline BG, Cursor Lines, Selections
+---@field one_bg string Pop-up Menu BG, Statusline Icon FG
+---@field one_bg2 string Tabline Inactive BG, Indent Line Context Start
+---@field one_bg3 string Tabline Toggle/New Btn, Borders
+---@field grey string Line Nr, Scrollbar, Indent Line Hover
+---@field grey_fg string Comment
+---@field grey_fg2 string Unused
+---@field light_grey string Diff Change, Tabline Inactive FG
+---@field red string Diff Delete, Diag Error
+---@field baby_pink string Some Dev Icons
+---@field pink string Indicators
+---@field line string Win Sep, Indent Line
+---@field green string Diff Add, Diag Info, Indicators
+---@field vibrant_green string Some Dev Icons
+---@field blue string UI Elements, Dev/CMP Icons
+---@field nord_blue string Indicators
+---@field yellow string Diag Warn
+---@field sun string Dev Icons
+---@field purple string Diag Hint, Dev/CMP Icons
+---@field dark_purple string Some Dev Icons
+---@field teal string Dev/CMP Icons
+---@field orange string Diff Mod
+---@field cyan string Dev/CMP Icons
 ---@field statusline_bg string
----@field lightbg string
----@field pmenu_bg string
----@field folder_bg string
+---@field lightbg string Statusline Components
+---@field pmenu_bg string Pop-up Menu Selection
+---@field folder_bg string Nvimtree Items


### PR DESCRIPTION
adding instructions to color bases, this will help users understanding the color roles while coding using autocompletion and hovering. 